### PR TITLE
Include `offset` in return value of `#records`

### DIFF
--- a/lib/airrecord/table.rb
+++ b/lib/airrecord/table.rb
@@ -1,5 +1,15 @@
 module Airrecord
   class Table
+    class RecordSet < SimpleDelegator
+      attr_reader :records, :offset
+
+      def initialize(records:, offset:)
+        @records = records
+        @offset = offset
+        __setobj__(@records)
+      end
+    end
+
     class << self
       attr_accessor :base_key, :table_name
       attr_writer :api_key
@@ -97,7 +107,7 @@ module Airrecord
             ))
           end
 
-          records
+          RecordSet.new(records: records, offset: parsed_response["offset"])
         else
           client.handle_error(response.status, parsed_response)
         end

--- a/test/table_test.rb
+++ b/test/table_test.rb
@@ -37,7 +37,13 @@ class TableTest < Minitest::Test
   end
 
   def test_retrieve_records
-    assert_instance_of Array, @table.records
+    assert_equal 2, @table.records.size
+  end
+
+  def test_records_includes_offset
+    stub_request([{"Name" => "1"}, {"Name" => "2"}], offset: 'dasfuhiu')
+
+    assert_equal 'dasfuhiu', @table.records(paginate: false).offset
   end
 
   def test_different_clients_with_different_api_keys


### PR DESCRIPTION
Currently, there are 2 modes for retrieving records; pagination on or off.

If pagination is on (`paginate: true`), we keep making fetch requests until the response does not include an `offset` for the next page.

If pagination is off (`paginate: false`), we simply fetch the first page and stop there.

In order to allow users to control pagination themselves (rather than simply on or off, as above) we need to provide access to the `offset` value returned by Airtable.